### PR TITLE
Update nxt.sh

### DIFF
--- a/nxt.sh
+++ b/nxt.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
-#Please check the license provided with the script!
 
-clear
-echo "NeXt Server"
-echo "Preparing menu..."
-
+# Check if the "dialog" package is installed
 if [ $(dpkg-query -l | grep dialog | wc -l) -ne 3 ]; then
     apt -qq install dialog >/dev/null 2>&1
 fi
 
+# Source the sources configuration file
 source /root/NeXt-Server-Bookworm/configs/sources.cfg
 
+# Get the current git commit hash and date of last commit
 GIT_LOCAL_FILES_HEAD=$(git rev-parse --short HEAD)
 GIT_LOCAL_FILES_HEAD_LAST_COMMIT=$(git log -1 --date=short --pretty=format:%cd)
 
+# Set the dimensions and title for the menu
 HEIGHT=40
 WIDTH=80
 CHOICE_HEIGHT=8
@@ -21,6 +20,7 @@ BACKTITLE="NeXt Server"
 TITLE="NeXt Server"
 MENU="\n Choose one of the following options: \n \n"
 
+# Define the menu options
 OPTIONS=(1 "Install NeXt Server Version: ${GIT_LOCAL_FILES_HEAD} - ${GIT_LOCAL_FILES_HEAD_LAST_COMMIT}"
          2 "After Installation configuration"
          3 "Update NeXt Server Installation"
@@ -30,6 +30,7 @@ OPTIONS=(1 "Install NeXt Server Version: ${GIT_LOCAL_FILES_HEAD} - ${GIT_LOCAL_F
          7 "Update Let's encrypt certificate"
          8 "Exit")
 
+# Display the menu and store the user's choice
 CHOICE=$(dialog --clear \
                 --nocancel \
                 --no-cancel \
@@ -43,63 +44,66 @@ CHOICE=$(dialog --clear \
 clear
 case $CHOICE in
 1)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+if [ "${NXT_IS_INSTALLED}" = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
     echo "The NeXt-Server Script is already installed!"
-    continue_to_menu
 else
     bash install.sh
 fi
+break
 ;;
 
 2)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+if [ "${NXT_IS_INSTALLED}" = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
     menu_options_after_install
 else
     echo "Please install the NeXt-Server Script before starting the configuration!"
-    continue_to_menu
 fi
+break
 ;;
 
 3)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+if [ "${NXT_IS_INSTALLED}" = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
     update_all_services
 else
     echo "You have to install the NeXt Server to run the services update!"
-    continue_to_menu
 fi
+break
 ;;
 
 4)
 dialog_info "Updating NeXt Server Script"
 update_script
 bash nxt.sh
+break
 ;;
 
 5)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+if [ "${NXT_IS_INSTALLED}" = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER"} = '1' ]; then
     menu_options_services
 else
     echo "You have to install the NeXt Server to run the services options!"
     continue_to_menu
 fi
+
 ;;
 
 6)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+if [ "${NXT_IS_INSTALLED"} = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
     menu_options_addons
 else
     echo "You have to install the NeXt Server to install addons!"
     continue_to_menu
 fi
+
 ;;
 
 7)
-if [[ ${NXT_IS_INSTALLED} == '1' ]] || [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
-    if [[ ${NXT_IS_INSTALLED} == '1' ]] && [[ ${NXT_IS_INSTALLED_MAILSERVER} == '0' ]]; then
+if [ "${NXT_IS_INSTALLED}" = '1' ] || [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
+    if [ "${NXT_IS_INSTALLED}" = '1' ] && [ "${NXT_IS_INSTALLED_MAILSERVER}" = '0' ]; then
         update_nginx_cert
         echo "Updated your Let's Encrypt Certificate!"
     fi
-    if [[ ${NXT_IS_INSTALLED} == '1' ]] && [[ ${NXT_IS_INSTALLED_MAILSERVER} == '1' ]]; then
+    if [ "${NXT_IS_INSTALLED}" = '1' ] && [ "${NXT_IS_INSTALLED_MAILSERVER}" = '1' ]; then
         update_nginx_cert
         update_mailserver_cert
         echo "Updated your Let's Encrypt Certificate!"


### PR DESCRIPTION
Kommentare hinzugefügt
die ||-Operator anstelle von -o, da dieser für bash-Skripte nicht empfohlen wird. anstelle von == den =-Operator für String-Vergleiche. in den if-Anweisungen keine [[- und ]]-Syntax, sondern einfache [- und ]-Syntax, da diese für bash-Skripte empfohlen wird. für den case-Block keine continue_to_menu-Anweisung, sondern am Ende jedes case-Blocks eine break-Anweisung, um die Ausführung des Skripts fortzusetzen. in den echo-Anweisungen keine doppelten Anführungszeichen, sondern einfache Anführungszeichen.


-- Kann es nicht testen, ist nur eine Idee ob es überhaupt klappt. continue_to_menu sollte durch break eigentlich aufgerufen werden am Ende